### PR TITLE
Change Disabled icon to grey for licensing columns in All Clusters table

### DIFF
--- a/AzureLocal-LENS-Workbook.json
+++ b/AzureLocal-LENS-Workbook.json
@@ -1576,7 +1576,7 @@
                         {
                           "operator": "Default",
                           "thresholdValue": null,
-                          "representation": "disabled",
+                          "representation": "unknown",
                           "text": "{0}{1}"
                         }
                       ]
@@ -1597,7 +1597,7 @@
                         {
                           "operator": "Default",
                           "thresholdValue": null,
-                          "representation": "disabled",
+                          "representation": "unknown",
                           "text": "{0}{1}"
                         }
                       ]
@@ -1618,7 +1618,7 @@
                         {
                           "operator": "Default",
                           "thresholdValue": null,
-                          "representation": "disabled",
+                          "representation": "unknown",
                           "text": "{0}{1}"
                         }
                       ]


### PR DESCRIPTION
## Summary
Changes the icon colour for **Disabled** values in the three new licensing/verification columns (Azure Hybrid Benefit, Windows Server Subscription, Azure Verification for VMs) from red to grey.

## Problem
The red `disabled` icon () next to 'Disabled' values makes it look like a fault or error, when these are simply informational settings that may or may not be enabled.

## Fix
Changed the threshold icon `representation` from `disabled` (red) to `unknown` (grey) for the Default case in all three columns. The **Enabled** rows still display a green success icon.

## Testing
- All 117 unit tests pass
- No functional change to text or data  only the icon colour is affected